### PR TITLE
Add 'make' as a build requirement.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2fae88f22a467e1fd3b7bc1d7965e844ed7ad9fea9b677e12148a99be8f63268
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
 
 requirements:
   build:
+    - make
     - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}


### PR DESCRIPTION
It seems 'cmake' doesn't depend on 'make', and the linux build was failing because of this.

Closes #6.
